### PR TITLE
Mark as version 1.1.0-ts1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>net.sf.jsi</groupId>
   <artifactId>jsi</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.0-ts1</version>
   <packaging>jar</packaging>
 
   <name>jsi</name>


### PR DESCRIPTION
Maven doesn't like -SNAPSHOT versions with its release plugin, so we're marking this as `1.1.0-ts1` 
(upstream this is just a -SNAPSHOT version)