### PR TITLE
DEVPROD-1736 Set owner

### DIFF
--- a/catalog-info.yml
+++ b/catalog-info.yml
@@ -1,0 +1,23 @@
+# catalog-info.yml
+# This file contains metadata for backstage
+# Read more about available fields and annotations:
+# https://github.com/tradeshift/backstage
+#
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: jsi
+  description: |
+    Java Spatial Index
+  annotations:
+    github.com/project-slug: Tradeshift/jsi # GitHub project name
+    sentry.io/project-slug: jsi # Name in sentry for enabling Sentry integration
+    backstage.io/kubernetes-id: jsi # Kubernetes app id, this is a Kubernetes label from the deployment of your service look for ex. app: backstage
+    # pagerduty.com/integration-key: a834115a04c748a5befc777442e209b8 # PagerDuty integration id from the service. Can be created in Pagerduty under Service Discovery -> Service name -> Integrations tab -> Add new integration. Please use the Events API v2, this might require you to chnage 'Alert and Incident Settings' on the 'Integrations tab' page.
+    sonarqube.org/project-key: jsi # Name of the project in SonarQube
+  tags:
+    - java
+spec:
+  type: library
+  owner: ml-team
+  lifecycle: production


### PR DESCRIPTION
Motivation: All repos should have a team owning them

According to the README.md, this is used as part of the machine learning model for image->pdf conversion for cloudscan in Backend-Conversions

So i am suggesting the ML team to own this.